### PR TITLE
convert_to_realizations to use clize

### DIFF
--- a/tests/improver-convert-to-realizations/01-basic.bats
+++ b/tests/improver-convert-to-realizations/01-basic.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "percentiles-to-realizations --sampling-method 'quantile' --no-of-percentiles 12 --rebadging input --output output" {
+  improver_check_skip_acceptance
+  KGO="percentiles-to-realizations/percentiles_rebadging/kgo.nc"
+
+  # Run Ensemble Copula Coupling to convert one set of percentiles to another
+  # set of percentiles, and then rebadge the percentiles to be ensemble
+  # realizations.
+  run improver percentiles-to-realizations  --sampling-method 'quantile' --no-of-percentiles 12 \
+      --rebadging \
+      "$IMPROVER_ACC_TEST_DIR/percentiles-to-realizations/percentiles_rebadging/multiple_percentiles_wind_cube.nc" \
+      --output "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}

--- a/tests/improver-convert-to-realizations/01-percentiles.bats
+++ b/tests/improver-convert-to-realizations/01-percentiles.bats
@@ -31,15 +31,14 @@
 
 . $IMPROVER_DIR/tests/lib/utils
 
-@test "percentiles-to-realizations --sampling-method 'quantile' --no-of-percentiles 12 --rebadging input --output output" {
+@test "convert-to-realizations --no-of-realizations 12 input --output output" {
   improver_check_skip_acceptance
   KGO="percentiles-to-realizations/percentiles_rebadging/kgo.nc"
 
   # Run Ensemble Copula Coupling to convert one set of percentiles to another
   # set of percentiles, and then rebadge the percentiles to be ensemble
   # realizations.
-  run improver percentiles-to-realizations  --sampling-method 'quantile' --no-of-percentiles 12 \
-      --rebadging \
+  run improver convert-to-realizations --no-of-realizations 12 \
       "$IMPROVER_ACC_TEST_DIR/percentiles-to-realizations/percentiles_rebadging/multiple_percentiles_wind_cube.nc" \
       --output "$TEST_DIR/output.nc"
   [[ "$status" -eq 0 ]]

--- a/tests/improver-convert-to-realizations/02-probabilities.bats
+++ b/tests/improver-convert-to-realizations/02-probabilities.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2017-2019 Met Office.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+. $IMPROVER_DIR/tests/lib/utils
+
+@test "convert-to-realizations --no-of-realizations 12 input --output output" {
+  improver_check_skip_acceptance
+  KGO="probabilities-to-realizations/12_realizations/kgo.nc"
+
+  run improver convert-to-realizations --no-of-realizations 12 \
+      "$IMPROVER_ACC_TEST_DIR/probabilities-to-realizations/basic/input.nc" \
+      --output "$TEST_DIR/output.nc"
+  [[ "$status" -eq 0 ]]
+
+  improver_check_recreate_kgo "output.nc" $KGO
+
+  # Run nccmp to compare the output and kgo.
+  improver_compare_output "$TEST_DIR/output.nc" \
+      "$IMPROVER_ACC_TEST_DIR/$KGO"
+}


### PR DESCRIPTION
Assumes that https://github.com/metoppv/improver/pull/1016 has gone in first, since it depends on `probabilites-to-realizations` and `percentiles-to-realizations` using `clize`.

(Also added somewhat redundant BATS tests which pick up results from those tests.)

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

(Note that after having pulled in some of the recent suite config changes, I'm beginning to think that we might not want to use this CLI at all... Still thinking about this.)